### PR TITLE
LocationLexicon: ignore places larger than a city

### DIFF
--- a/src/edu/stanford/nlp/sempre/LocationLexicon.java
+++ b/src/edu/stanford/nlp/sempre/LocationLexicon.java
@@ -64,8 +64,10 @@ public class LocationLexicon extends AbstractLexicon<LocationValue> {
 
   private static <E1, E2> Collection<E2> map(Collection<E1> from, Function<E1, E2> f) {
     Collection<E2> to = new ArrayList<>();
-    for (E1 e : from)
-      to.add(f.apply(e));
+    for (E1 e1 : from) {
+      E2 e2 = f.apply(e1);
+      to.add(e2);
+    }
     return to;
   }
 
@@ -84,8 +86,9 @@ public class LocationLexicon extends AbstractLexicon<LocationValue> {
       try (Reader reader = new InputStreamReader(connection.getInputStream())) {
         return map(Json.getMapper().reader().withType(new TypeReference<List<NominatimEntry>>() {
         }).readValue(reader), (NominatimEntry entry) -> {
+          int rank = Integer.parseInt(entry.place_rank);
           String canonical = entry.display_name.toLowerCase().replaceAll("[,\\s+]", " ");
-          return new Entry<>("LOCATION", new LocationValue(entry.lat, entry.lon, entry.display_name),
+          return new Entry<>("LOCATION", new LocationValue(entry.lat, entry.lon, entry.display_name, rank),
               canonical);
         });
       }

--- a/src/edu/stanford/nlp/sempre/LocationValue.java
+++ b/src/edu/stanford/nlp/sempre/LocationValue.java
@@ -9,17 +9,31 @@ public class LocationValue {
   private final double longitude;
   @JsonProperty
   private final String display;
+  private final int rank;
 
   public LocationValue(double latitude, double longitude) {
     this.latitude = latitude;
     this.longitude = longitude;
     this.display = null;
+    this.rank = 30;
   }
 
   public LocationValue(double latitude, double longitude, String display) {
     this.latitude = latitude;
     this.longitude = longitude;
     this.display = display;
+    this.rank = 30;
+  }
+
+  public LocationValue(double latitude, double longitude, String display, int rank) {
+    this.latitude = latitude;
+    this.longitude = longitude;
+    this.display = display;
+    this.rank = rank;
+  }
+
+  public int getRank() {
+    return this.rank;
   }
 
   @Override

--- a/src/edu/stanford/nlp/sempre/Seq2SeqTokenizer.java
+++ b/src/edu/stanford/nlp/sempre/Seq2SeqTokenizer.java
@@ -230,6 +230,8 @@ public class Seq2SeqTokenizer {
       return null;
 
     LocationLexicon.Entry<LocationValue> first = entries.iterator().next();
+    if (first.value.getRank() < 16) // larger than a city
+        return null;
     return first.value;
   }
 


### PR DESCRIPTION
Countries and states should be represented as the corresponding
entity type in ThingTalk, not a Location type (longitude/latitude
pair), even though they get recognized as LOCATION by CoreNLP.

Simply leaving countries and states untokenized is enough, as they will
be picked up by quote-free entity recognition at the parser level.