### PR TITLE
Create lib/ if not exists

### DIFF
--- a/pull-dependencies.sh
+++ b/pull-dependencies.sh
@@ -13,6 +13,7 @@ pullparmesan() {
 }
 
 cd $SEMPREDIR
+if [! -d lib]; then mkdir lib; fi
 pullsempre '/u/nlp/data/semparse/resources/guava-14.0.1.jar'
 # TestNG -- testing framework
 pullsempre '/u/nlp/data/semparse/resources/testng-6.8.5.jar'

--- a/pull-dependencies.sh
+++ b/pull-dependencies.sh
@@ -13,7 +13,7 @@ pullparmesan() {
 }
 
 cd $SEMPREDIR
-if [! -d lib]; then mkdir lib; fi
+mkdir -p lib
 pullsempre '/u/nlp/data/semparse/resources/guava-14.0.1.jar'
 # TestNG -- testing framework
 pullsempre '/u/nlp/data/semparse/resources/testng-6.8.5.jar'


### PR DESCRIPTION
When pulling dependencies down, I encountered an error because the `lib/` folder was not there. So I revised it to create the folder if it doesn't exist before downloading any dependencies.