### PR TITLE
Fix Null Date Value Error

### DIFF
--- a/src/edu/stanford/nlp/sempre/CoreNLPAnalyzer.java
+++ b/src/edu/stanford/nlp/sempre/CoreNLPAnalyzer.java
@@ -168,8 +168,12 @@ public class CoreNLPAnalyzer {
         addComma = true;
       }
 
-      if (nerTag.equals("DATE") && INTEGER_PATTERN.matcher(nerValue).matches()) {
-        nerTag = "NUMBER";
+      if (nerTag.equals("DATE")) {
+        if (nerValue == null) {
+          nerTag = "O";
+        } else if (INTEGER_PATTERN.matcher(nerValue).matches()) {
+          nerTag = "NUMBER";
+        }
       }
 
       if (wordLower.equals("9-11") || wordLower.equals("911")) {

--- a/src/edu/stanford/nlp/sempre/DateValue.java
+++ b/src/edu/stanford/nlp/sempre/DateValue.java
@@ -26,7 +26,7 @@ public class DateValue {
   // Format: YYYY-MM-DD (from Freebase).
   // Return null if it's not a valid date string.
   public static DateValue parseDateValue(String dateStr) {
-    if (dateStr.equals("PRESENT_REF") || dateStr.equals("XXXX-XX-XX"))
+    if (dateStr == null || dateStr.equals("PRESENT_REF") || dateStr.equals("XXXX-XX-XX"))
       return null;
 
     Matcher matcher = PATTERN.matcher(dateStr);


### PR DESCRIPTION
When parsing Chinese sentences, the word "最近" (recent) is recognized as DATE by the CoreNLP NER. "最近" is a simple term. But in our original design, each __DATE__ is supposed to have __at least a value__ with it. Then the following error comes out:
```
[pool-1-thread-4] INFO edu.stanford.nlp.wordseg.CorpusChar - Loading char[0/186]
ictionary file from edu/stanford/nlp/models/segmenter/chinese/dict/character_lis
t [done].
[pool-1-thread-4] INFO edu.stanford.nlp.wordseg.AffixDictionary - Loading affix
dictionary from edu/stanford/nlp/models/segmenter/chinese/dict/in.ctb [done].
Exception in thread "pool-1-thread-4" java.lang.NullPointerException
       at java.util.regex.Matcher.getTextLength(Matcher.java:1283)
       at java.util.regex.Matcher.reset(Matcher.java:309)
       at java.util.regex.Matcher.<init>(Matcher.java:229)
       at java.util.regex.Pattern.matcher(Pattern.java:1093)
       at edu.stanford.nlp.sempre.CoreNLPAnalyzer.analyze(CoreNLPAnalyzer.java$
171)
       at edu.stanford.nlp.sempre.Example.preprocess(Example.java:98)
       at edu.stanford.nlp.sempre.TokenizerServer.processInput(TokenizerServer.
java:152)
       at edu.stanford.nlp.sempre.TokenizerServer.lambda$handleConnection$1(Tok
enizerServer.java:192)
       at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor$
java:1149)
       at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecuto$
.java:624)
       at java.lang.Thread.run(Thread.java:748)
```

The solution here is to change the entity name of null valued DATE to nothing (__O__).

The test of `./scripts/test-tokenizer.py < data/test-tokenizer-en.yml` passed. And also it works with the Chinese sentences which failed before this modification.