### PR TITLE
Remove systemd-notify support

### DIFF
--- a/pull-dependencies.sh
+++ b/pull-dependencies.sh
@@ -41,8 +41,6 @@ pullparmesan 'stanford-english-corenlp-2017-06-09-models.jar'
 pullparmesan 'stanford-chinese-corenlp-2017-06-09-models.jar'
 pullparmesan 'trove4j-3.0.3.jar'
 pullparmesan 'trove4j-3.0.3-javadoc.jar'
-pullparmesan 'jna.jar'
-wget -c 'http://search.maven.org/remotecontent?filepath=info/faljse/SDNotify/1.1/SDNotify-1.1.jar' -O lib/SDNotify-1.1.jar
 
 # OpenCC
 pullopencc 'v0.1/OpenCC-Java-all-0.1.jar'

--- a/src/edu/stanford/nlp/sempre/TokenizerServer.java
+++ b/src/edu/stanford/nlp/sempre/TokenizerServer.java
@@ -13,8 +13,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.ObjectWriter;
 
-import info.faljse.SDNotify.SDNotify;
-
 public class TokenizerServer {
   private static final int DEFAULT_PORT = 8888;
 
@@ -100,7 +98,6 @@ public class TokenizerServer {
         .disable(JsonParser.Feature.AUTO_CLOSE_SOURCE);
 
     server = new ServerSocket(port);
-    SDNotify.sendNotify();
   }
 
   public void run() throws IOException {


### PR DESCRIPTION
Since genie has learned to reconnect to the tokenizer as needed,
synchronization of the parser and tokenizer is not as important,
and systemd-notify brings in the annoying jna library, so let's
remove it.