### PR TITLE
italian: add a workaround for tokenization around _

### DIFF
--- a/data/test-tokenizer-it.yml
+++ b/data/test-tokenizer-it.yml
@@ -178,3 +178,18 @@
     NUMBER_1: 7200001
     NUMBER_2: 750021
     NUMBER_3: 800250323
+- locale: it-IT
+  input: cerca ____ su bing
+  rawTokens: cerca ____ su bing
+  tokens: cerca ____ su bing
+  entities: {}
+- locale: it-IT
+  input: cerca____su bing
+  rawTokens: cerca ____ su bing
+  tokens: cerca ____ su bing
+  entities: {}
+- locale: it-IT
+  input: cerca____,____su bing
+  rawTokens: cerca ____ , ____ su bing
+  tokens: cerca ____ , ____ su bing
+  entities: {}

--- a/src/edu/stanford/nlp/sempre/CoreNLPAnalyzer.java
+++ b/src/edu/stanford/nlp/sempre/CoreNLPAnalyzer.java
@@ -9,6 +9,7 @@ import edu.stanford.nlp.ling.CoreAnnotations.*;
 import edu.stanford.nlp.ling.CoreLabel;
 import edu.stanford.nlp.pipeline.Annotation;
 import edu.stanford.nlp.pipeline.StanfordCoreNLP;
+import edu.stanford.nlp.sempre.italian.ItalianTokenizerBlankWorkaround;
 import edu.stanford.nlp.sentiment.SentimentCoreAnnotations;
 import edu.stanford.nlp.util.CoreMap;
 import edu.stanford.nlp.util.logging.Redwood;
@@ -64,7 +65,7 @@ public class CoreNLPAnalyzer {
     case "it":
       loadResource("StanfordCoreNLP-italian.properties", props);
       props.put("ita_toksent.ssplitOnlyOnNewLine", "true");
-      annotators = "ita_toksent,mergesent,quote2,pos,ita_morpho,ita_lemma,ner,quote_ner,custom_regexp_ner,custom_numeric_ner,phone_ner,url_ner,parse,sentiment";
+      annotators = "ita_toksent,ita_tok_workaround,mergesent,quote2,pos,ita_morpho,ita_lemma,ner,quote_ner,custom_regexp_ner,custom_numeric_ner,phone_ner,url_ner,parse,sentiment";
       break;
 
     case "de":
@@ -99,6 +100,7 @@ public class CoreNLPAnalyzer {
     props.put("regexner.backgroundSymbol", "O,MISC,ORGANIZATION");
 
     // move quotes to a NER tag
+    props.put("customAnnotatorClass.ita_tok_workaround", ItalianTokenizerBlankWorkaround.class.getCanonicalName());
     props.put("customAnnotatorClass.mergesent", MergeSentencesAnnotator.class.getCanonicalName());
     props.put("customAnnotatorClass.quote2", QuotedStringAnnotator.class.getCanonicalName());
     props.put("customAnnotatorClass.quote_ner", QuotedStringEntityAnnotator.class.getCanonicalName());

--- a/src/edu/stanford/nlp/sempre/MergeSentencesAnnotator.java
+++ b/src/edu/stanford/nlp/sempre/MergeSentencesAnnotator.java
@@ -32,12 +32,15 @@ public class MergeSentencesAnnotator implements Annotator {
     newSentence.set(CoreAnnotations.CharacterOffsetBeginAnnotation.class, 0);
     newSentence.set(CoreAnnotations.CharacterOffsetEndAnnotation.class, originalText.length());
     newSentence.set(CoreAnnotations.SentenceIndexAnnotation.class, 0);
-    
+
     List<CoreLabel> tokens = new ArrayList<>();
     for (CoreMap sentence : document.get(CoreAnnotations.SentencesAnnotation.class))
       tokens.addAll(sentence.get(CoreAnnotations.TokensAnnotation.class));
-   
+
+    for (int i = 0; i < tokens.size(); i++)
+      tokens.get(i).set(CoreAnnotations.IndexAnnotation.class, i);
     newSentence.set(CoreAnnotations.TokensAnnotation.class, tokens);
+    document.set(CoreAnnotations.TokensAnnotation.class, tokens);
     document.set(CoreAnnotations.SentencesAnnotation.class, Collections.singletonList(newSentence));
   }
 

--- a/src/edu/stanford/nlp/sempre/italian/ItalianTokenizerBlankWorkaround.java
+++ b/src/edu/stanford/nlp/sempre/italian/ItalianTokenizerBlankWorkaround.java
@@ -1,0 +1,62 @@
+package edu.stanford.nlp.sempre.italian;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Set;
+
+import edu.stanford.nlp.ling.CoreAnnotation;
+import edu.stanford.nlp.ling.CoreAnnotations;
+import edu.stanford.nlp.ling.CoreLabel;
+import edu.stanford.nlp.pipeline.Annotation;
+import edu.stanford.nlp.pipeline.Annotator;
+import edu.stanford.nlp.util.ArraySet;
+import edu.stanford.nlp.util.CoreMap;
+
+public class ItalianTokenizerBlankWorkaround implements Annotator {
+
+  @Override
+  public void annotate(Annotation document) {
+    for (CoreMap sentence : document.get(CoreAnnotations.SentencesAnnotation.class)) {
+      boolean prevIsUnderscore = false;
+      CoreLabel prevword = null;
+      
+      Iterator<CoreLabel> it = sentence.get(CoreAnnotations.TokensAnnotation.class).iterator();
+      while (it.hasNext()) {
+        CoreLabel token = it.next();
+        boolean isUnderscore = "_".equals(token.word());
+        
+        if (isUnderscore) {
+          if (prevIsUnderscore) {
+            assert prevword != null;
+            prevword.setWord(prevword.word() + "_");
+            prevword.setValue(prevword.value() + "_");
+            prevword.set(CoreAnnotations.OriginalTextAnnotation.class, token.get(CoreAnnotations.OriginalTextAnnotation.class) + "_");
+            prevword.set(CoreAnnotations.CharacterOffsetEndAnnotation.class, token.get(CoreAnnotations.CharacterOffsetEndAnnotation.class));
+            it.remove();
+          } else {
+            prevIsUnderscore = true;
+            prevword = token;
+          }
+        } else {
+          prevIsUnderscore = false;
+          prevword = null;
+        }
+      }
+    }
+  }
+
+  @Override
+  public Set<Class<? extends CoreAnnotation>> requirementsSatisfied() {
+    return Collections.emptySet();
+  }
+
+  @Override
+  public Set<Class<? extends CoreAnnotation>> requires() {
+    return Collections.unmodifiableSet(new ArraySet<>(Arrays.asList(
+        CoreAnnotations.TextAnnotation.class,
+        CoreAnnotations.TokensAnnotation.class,
+        CoreAnnotations.SentencesAnnotation.class)));
+  }
+
+}


### PR DESCRIPTION
Almond assumes that consecutive sequences of underscores will be preserved
as a single token (and uses this fact to preprocess Thingpedia)

Fixes #31